### PR TITLE
Update bescort.lic

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -716,6 +716,8 @@ class Bescort
   end
 
   def segoltha(mode)
+    EquipmentManager.new.empty_hands
+    EquipmentManager.new.wear_equipment_set?('swimming')
     if mode =~ /^n/i
       dir_of_travel = 'north'
       start_room = 19_373
@@ -742,6 +744,7 @@ class Bescort
         break
       end
     end
+    EquipmentManager.new.wear_equipment_set?('swimming')
   end
 
   def croc_swamp(mode)


### PR DESCRIPTION
Use equipment manager to change into swimming gearset before swimming the Segoltha, then change back to standard when done.