### PR TITLE
New changes

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -1,22 +1,5 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#rezz
-  
-  Define a waggle sets for rezz and rejuv if you don't want to use the default values in base-spells.yaml
-  
-  EXAMPLE
-  waggle_sets:
-    rezz:
-      Resurrection:
-        mana: 17
-    rejuv:
-      Rejuvenation:
-        mana: 10
-        cambrinth:
-        - 15
-
-  In order to infuse directly from your mana pool add the following to your yaml:
-  osrel_no_harness: true
-  
 =end
 
 custom_require.call(%w[common common-arcana events drinfomon spellmonitor])
@@ -30,103 +13,114 @@ class Rezz
 	
     arg_definitions = [
       [
-        { name: 'person', regex: /\w+/, description: 'Person to rezz' }
+        { name: 'player', regex: /\w+/, optional: true, description: 'Name of the player to rezz' }
       ]
     ]
 	
     args = parse_args(arg_definitions)
     @settings = get_settings
-    
-    @person = args.person.capitalize
-	/the body of (#{@person}.*) who/ =~ bput('look people', /the body of (#{@person}.*) who/)
-	@person = Regexp.last_match(1)
-    
-    @rezz = if @settings.waggle_sets['rezz']
-               @settings.waggle_sets['rezz'].values.first
-           else
-	         get_data('spells').spell_data['Resurrection']
-	       end
-    	   
-    @rejuv = if @settings.waggle_sets['rejuv']
-               @settings.waggle_sets['rejuv'].values.first
-           else
-	         get_data('spells').spell_data['Rejuvenation']
-	       end
-
-    @rejuv['cast'] = "cast #{@person}"
 	
-	check_favor
-    rejuv
-    cast_rezz
-    find_soul
-    soul_bond
-    rejuv(true)
-    gesture
-  end
-  
-  def check_favor
-    Flags.add('no-favor', /(#{@person}.*) has no favor with (.*) god/)
-    bput("perc #{@person}", /#{@person} has (.*) favors with (his|her) god/)
-    Flags['no-favor'] ? begin echo "*** #{@person} has no favors! ***"; exit end : nil
-  end
-  
-  def rejuv(quick = false)
-    quick ? begin @rejuv['cambrinth'] = []; @rejuv['prep_time'] = 5; @rejuv['mana'] = 5 end : nil
-    Flags.add('wrong-name', "You can't cast that at yourself")
-    Flags.add('silver', 'A thin silver nimbus surrounds')
+	args.player ? @target = DRRoom.pcs.find { |name| /^#{args.player}/i =~ name }.to_a : find_dead
+	!@target ? begin echo "*** No bodies! ***"; exit end : nil
+	
+    @rezz = if @settings.waggle_sets['rezz']['Resurrection']
+              @settings.waggle_sets['rezz']['Resurrection']
+			else
+			  echo "Using default values for REZZ, make a 'rezz'=>Resurrection waggle set to avoid this."
+			  get_data('spells').spell_data['Resurrection']
+			end
+
+    @rejuv = if @settings.waggle_sets['rezz']['Rejuvenation']
+	           @settings.waggle_sets['rezz']['Rejuvenation']
+			 else
+			   echo "Using default values for REJUV, make a 'rezz'=>Rejuvenation waggle set to avoid this."
+	           get_data('spells').spell_data['Rejuvenation']
+			 end
+
+    Flags.add('no-favor', /has no favor with h.. god!/)
+    Flags.add('rejuv-silver', 'A thin silver nimbus surrounds', 'As you concentrate, a thin silver nimbus flickers into view around')
     Flags.add('alive', 'Nothing happens')
-    until Flags['silver'] || Flags['alive'] || Flags['wrong-name']
-	  pause 1 while DRStats.mana < 50
-      cast_spell(@rejuv, @settings)
-  	  pause 0.5
-    end
-    Flags['alive'] ? begin echo "*** #{@person} is already alive, dumbass! ***"; exit end : nil
-    Flags['wrong-name'] ? begin echo "*** Name spelled incorrectly. ***"; exit end : nil
+    Flags.add('necro', 'has no protection from the gods. judgment')
+
+    @target.each do |name|
+      @rejuv['cast'] = "cast #{name}"
+	  rejuv_process(name)
+      Flags['alive'] ? begin echo "*** #{name} is already alive, dumbass! ***"; next end : nil
+      Flags['no-favor'] ? begin echo "*** #{name} has no favors! ***"; next end : nil
+      rezz_process(name)
+	end
+  end
+
+  def find_dead
+    /You take a moment to look for everybody in the area and see (.*)/ =~ bput('look people', "You look around and notice that you're the only one in the area", /You take a moment to look for everybody in the area and see (.*)/)
+    @target = Regexp.last_match(1).sub(/ and /, ', ').scan(/the body of ([a-z[:blank:]]+) who is [a-z[:blank:]]+?,?./i).flatten.map { |obj| obj.split.last }
+	@target == [] ? @target = nil : nil
+  end
+
+  def rejuv(player, quick = false)
     Flags.reset('rejuv-silver')
-  end
-    
-  def cast_rezz
-    Flags.add('rezz-ready', 'You prepare to look for the lost spirits of the dead')
-    Flags.add('rezz-not-prepped', 'This pattern may only be cast with full preparation')
-    cast_spell(@rezz, @settings)
-    if Flags['rezz-not-prepped']
-      while Flags['rezz-not-prepped'] 
-	    Flags.reset('rezz-not-prepped')
-        pause 1
-	    bput('cast', get_data('spells').cast_messages, )
-	  end
-    end
-    while !Flags['rezz-ready']
-      pause 0.5
+    quick ? begin @rejuv['cambrinth'] = []; @rejuv['prep_time'] = 5; @rejuv['mana'] = 10 end : nil
+    until Flags['rejuv-silver'] || Flags['alive'] || Flags['necro']
+	  pause 5 while DRStats.mana < 40
+      cast_spell(@rejuv, @settings)
     end
   end
-  
-  def find_soul
-    Flags.add('soul-found', /sense the spirit of #{@person} in the Void/i)
-    while !Flags['soul-found']
-      pause 1 while DRStats.mana < 50
+
+  def find_soul(player)
+    10.times do
+	  pause 5 while DRStats.mana < 40
       @settings.osrel_no_harness ? nil : harness_mana([@rezz['mana']])
-      bput("infuse rezz #{@rezz['mana']}", /sense the spirit of #{@person} in the Void/i, 'You sense a spirit nearby, but you are unable to make it out clearly.')
+      match = bput("infuse rezz #{@rezz['mana']}", 'You sense a spirit nearby, but you are unable to make it out clearly', /spirit of #{player}/)
+	  @infuse_attempts += 1
+	  return true if match.eql? "spirit of #{player}"
+    end
+	return false
+  end
+
+  def keep_going
+    respond("*** Not found after #{@infuse_attempts} infuses so far. Do you want to continue? ***")
+    respond("*** To continue: ;send yes ***")
+	respond("*** To give up: ;send no ***")
+
+    line = get until line.strip =~ /^(yes|no)$/i
+    case line
+    when /^yes$/i
+      return true
+    when /^no$/i
+      respond("*** Exiting script!  QUITTER!! ***")
+      fput('release')
+      return false
     end
   end
-  
-  def soul_bond
-    data = { 'abbrev' => 'SB', 'prep_time' => 8, 'cast' => "cast #{@person}", 'mana' => 5 }
-    cast_spell(data, @settings)
-  end
-  
-  def gesture
-    case bput("gesture #{@person}", /#{@person} spirit lets out a frustrated lament/, /You have not yet found #{@person} spirit in the Void/, 'Roundtime')
-    when /#{@person} spirit lets out a frustrated lament/
-      soul_bond
-  	  rejuv(true)
-	  gesture
-    when /You have not yet found #{@person} spirit in the Void/
-      find_soul
-  	  rejuv(true)
-	  gesture
-    end
+
+  def rejuv_process(player)
+    Flags.reset('alive')
+    Flags.reset('no-favor')
+    bput("perc #{player}", /#{player} has (.*) favors* with (his|her) god/, /has no favor with h.. god!/)
+    Flags['rejuv-silver'] ? nil : rejuv(player)
+  end	
+
+  def rezz_process(player)
+    cast_spell(@rezz, @settings)
+	bput('cast', get_data('spells').cast_messages) until DRSpells.active_spells['Resurrection']
+	waitfor('You prepare to look for the lost spirits of the dead')
+	
+	until find_soul(player)
+	  keep_going ? nil : begin fput("whisper #{player} I can't find your soul, you need more favors!"); exit end
+	end
+
+    cast_spell({ 'abbrev' => 'SB', 'prep_time' => 2, 'cast' => "cast #{player}", 'mana' => 3 }, @settings)
+    rejuv(player, true)
+
+    case bput("gesture #{player}", 'Roundtime', 'gift of life to a body that badly broken')
+	when 'gift of life to a body that badly broken'
+	  fput("'#{player} still needs healing.")
+	  return
+	end
+	echo "*** It took #{@infuse_attempts*@rezz['mana']} infused mana to find #{player}'s soul. ***"
   end
 end
 
+start_time = Time.now.to_f
 Rezz.new
+echo "runtime: #{((Time.now.to_f - start_time) / 60.00).as_time}"


### PR DESCRIPTION
Ok, new changes:
;rezz by itself will raise all corpses in the room
;rezz <target> will only raise that person.

Put both Rejuv and Rezz in 1 waggle set, and now it gives a message if you don't have it setup.

Now the script only does the 'look people' if you run it without any arguments so it can check for dead people.

Made the methods more efficient and removed some of the unnecessary ones.

They're now called with rejuv_process and rezz_process.

If soul isn't found in 10 infuses, it gives the option to give up or keep going.  If you keep going, it will do 10 more and ask again as many times as you let it continue.

I added the script runtime displaying at the end because I was curious.  That can stay or go, whatever is appropriate.

The only thing I can think of that isn't handled is if the body is either dragged off or someone else raises them first.
If they get raised while you're still rejuving, it will deal with it.  But not after that.

I could add some more messages to the 'alive' flag.   "You can't cast that at yourself." will show up both if you try to rejuv or soul bond someone who isn't there.

Oh, just added one more flag for if the person is a necro.  I ran across a dead one while testing and noticed that they have a different message when you perceive them.