### PR TITLE
Quick fix

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -86,10 +86,10 @@ class Rezz
     10.times do
       pause 5 while DRStats.mana < 40
       @settings.osrel_no_harness ? nil : harness_mana([@rezz['mana']])
-      match = bput("infuse rezz #{@rezz['mana']}", 'You sense a spirit nearby, but you are unable to make it out clearly', /spirit of #{player}/)
+      match = bput("infuse rezz #{@rezz['mana']}", 'You sense a spirit nearby, but you are unable to make it out clearly', /spirit of #{player} in the Void/)
       @infuse_attempts += 1
       vigil(player) if Flags['rotting']
-      return true if match.eql? "spirit of #{player}"
+      return true if match.eql? "spirit of #{player} in the Void"
     end
     return false
   end


### PR DESCRIPTION
Added "in the Void" to the end of the match that lets the script know you found the soul because the corpse whispering to you can screw it up the way it is now.

The grating, wraithlike spirit of Name whispers
That caused the script to stop infusing and soul bond then gesture.